### PR TITLE
Implement sizeOf, getFileByteRangeAsReadable and improved AWS performance

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ dist
 .vscode
 tests/test.jpg
 tests/tmp/
+.idea

--- a/src/AbstractStorage.ts
+++ b/src/AbstractStorage.ts
@@ -64,7 +64,11 @@ export abstract class AbstractStorage implements IStorage {
 
   abstract async getFileAsReadable(name: string): Promise<Readable>;
 
+  abstract async getFileByteRangeAsReadable(name: string, start: number, length?: number): Promise<Readable>;
+
   abstract async removeFile(fileName: string): Promise<void>;
 
   abstract async listFiles(): Promise<[string, number][]>;
+
+  abstract async sizeOf(name: string): Promise<number>;
 }

--- a/src/Storage.ts
+++ b/src/Storage.ts
@@ -56,6 +56,10 @@ export class Storage implements IStorage {
     return this.storage.getFileAsReadable(name);
   }
 
+  async getFileByteRangeAsReadable(name: string, start: number, length?: number): Promise<Readable> {
+    return this.storage.getFileByteRangeAsReadable(name, start, length);
+  }
+
   async removeFile(fileName: string): Promise<void> {
     return this.storage.removeFile(fileName);
   }
@@ -78,5 +82,9 @@ export class Storage implements IStorage {
     } else {
       throw new Error('Not a supported configuration');
     }
+  }
+
+  async sizeOf(name: string) : Promise<number> {
+    return this.storage.sizeOf(name);
   }
 }

--- a/src/StorageLocal.ts
+++ b/src/StorageLocal.ts
@@ -178,6 +178,19 @@ export class StorageLocal extends AbstractStorage implements IStorage {
     return fs.createReadStream(p);
   }
 
+  async getFileByteRangeAsReadable(name: string, start: number, length?: number): Promise<Readable> {
+    let readLength = length;
+    if (readLength == null) {
+      readLength = await this.sizeOf(name);
+    }else {
+      readLength += start;
+    }
+
+    const p = path.join(this.directory, this.bucketName, name);
+    await fs.promises.stat(p);
+    return fs.createReadStream(p, { start, end: readLength });
+  }
+
   async removeFile(fileName: string): Promise<void> {
     const p = path.join(this.directory, this.bucketName, fileName);
     const [err] = await to(fs.promises.unlink(p));
@@ -188,5 +201,11 @@ export class StorageLocal extends AbstractStorage implements IStorage {
       }
       throw new Error(err.message);
     }
+  }
+
+  async sizeOf(name: string): Promise<number> {
+    const p = path.join(this.directory, this.bucketName, name);
+    const stat = await fs.promises.stat(p);
+    return stat.size;
   }
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -62,6 +62,13 @@ export interface IStorage {
   getFileAsReadable(name: string): Promise<Readable>;
 
   /**
+   * @param name: name of the file to be returned as a readable stream
+   * @param start: the first byte to return from
+   * @param length?: the number of bytes to return from the start
+   */
+  getFileByteRangeAsReadable(name: string, start: number, length?: number): Promise<Readable>;
+
+  /**
    * @param name: name of the file to be removed
    */
   removeFile(name: string): Promise<void>;
@@ -71,6 +78,12 @@ export interface IStorage {
    * selected bucket. If no bucket is selected an error will be thrown.
    */
   listFiles(): Promise<[string, number][]>;
+
+  /**
+   * Returns the size in bytes of the file
+   * @param name
+   */
+  sizeOf(name: string): Promise<number>;
 }
 
 export type ConfigAmazonS3 = {


### PR DESCRIPTION
sizeOf will return the size of the object without retrieving it.
getFileByteRangeAsReadable allows for partial file retrieval from a byte range.

Performance increase in S3 adapter for getFileAsReadable.