### PR TITLE
Reverse changelog so newest entries are on top

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,35 +1,11 @@
-# 1.1.16
+# 1.4.2
 
-(Pull request #1)[https://github.com/tweedegolf/storage-abstraction/pull/1]
+- Added `ConfigAmazonS3`, `ConfigBackblazeB2`, `ConfigGoogleCloud` and `ConfigLocal` to exported types
+- Removed `await-to-js` dependency
 
-- Expanded the S3 configuration options
+# 1.4.1
 
-# 1.2.1
-
-(Pull request #3)[https://github.com/tweedegolf/storage-abstraction/pull/3]
-
-- Implemented `sizeOf`, `getFileByteRangeAsReadable`
-- Improved AWS performance
-
-# 1.3.0
-
-- Removed `getFileByteRangeAsReadable` and merged the functionality in `getFileAsReadable` by adding a range parameter `{start: number, end: number}`
-- Removed the option to instantiate a specific storage type directly; all instantiating must be done with `new Storage(config)`.
-- Optimized `getFileAsReadable` for Google Cloud.
-- Implemented `addFileFromReadable`, fixes [issue#2](https://github.com/tweedegolf/storage-abstraction/issues/2)
-- Added configuration urls: all configuration options in a single string.
-- When creating a local storage without specifying a directory, the directory where the process runs will be used (in earlier versions the os' tmp folder was used)
-- When creating a local storage without specifying a bucket name, a directory named `local-bucket` will be created and used as selected bucket.
-- When using `new Storage()` without configuration you create a local storage instance with the default configuration (as described in the 2 bullets above).
-- Updated documentation.
-- Updated dependency version.
-- Added yarn.lock.
-- Renamed 'functional classes' to 'adapter classes'
-
-# 1.3.1
-
-- Removed sloppy code: parsing and validation of configuration is now done in one [place](https://github.com/tweedegolf/storage-abstraction/blob/master/src/util.ts).
-- Removed jasmine-ts dependency
+- Added `AdapterConfig` to exported types
 
 # 1.4.0
 
@@ -47,11 +23,35 @@
 - Removed options from both configuration and adapters.
 - Formalized return values
 
-# 1.4.1
+# 1.3.1
 
-- Added `AdapterConfig` to exported types
+- Removed sloppy code: parsing and validation of configuration is now done in one [place](https://github.com/tweedegolf/storage-abstraction/blob/master/src/util.ts).
+- Removed jasmine-ts dependency
 
-# 1.4.2
+# 1.3.0
 
-- Added `ConfigAmazonS3`, `ConfigBackblazeB2`, `ConfigGoogleCloud` and `ConfigLocal` to exported types
-- Removed `await-to-js` dependency
+- Removed `getFileByteRangeAsReadable` and merged the functionality in `getFileAsReadable` by adding a range parameter `{start: number, end: number}`
+- Removed the option to instantiate a specific storage type directly; all instantiating must be done with `new Storage(config)`.
+- Optimized `getFileAsReadable` for Google Cloud.
+- Implemented `addFileFromReadable`, fixes [issue#2](https://github.com/tweedegolf/storage-abstraction/issues/2)
+- Added configuration urls: all configuration options in a single string.
+- When creating a local storage without specifying a directory, the directory where the process runs will be used (in earlier versions the os' tmp folder was used)
+- When creating a local storage without specifying a bucket name, a directory named `local-bucket` will be created and used as selected bucket.
+- When using `new Storage()` without configuration you create a local storage instance with the default configuration (as described in the 2 bullets above).
+- Updated documentation.
+- Updated dependency version.
+- Added yarn.lock.
+- Renamed 'functional classes' to 'adapter classes'
+
+# 1.2.1
+
+(Pull request #3)[https://github.com/tweedegolf/storage-abstraction/pull/3]
+
+- Implemented `sizeOf`, `getFileByteRangeAsReadable`
+- Improved AWS performance
+
+# 1.1.16
+
+(Pull request #1)[https://github.com/tweedegolf/storage-abstraction/pull/1]
+
+- Expanded the S3 configuration options


### PR DESCRIPTION
This change reverses the changelog so newest entries are on top. This means that you can more quickly see what recently changed, instead of first seeing the same old changes that will never be different from an old version that is no longer relevant.