### PR TITLE
Make keyFilename optional for GCS

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,39 +9,39 @@ Because the API only provides basic storage operations (see [below](#api-methods
 <!-- toc -->
 
 - [Instantiate a storage](#instantiate-a-storage)
-  * [Configuration object](#configuration-object)
-  * [Configuration URL](#configuration-url)
+  - [Configuration object](#configuration-object)
+  - [Configuration URL](#configuration-url)
 - [Adapters](#adapters)
-  * [Local storage](#local-storage)
-  * [Google Cloud](#google-cloud)
-  * [Amazon S3](#amazon-s3)
-  * [Backblaze B2](#backblaze-b2)
+  - [Local storage](#local-storage)
+  - [Google Cloud](#google-cloud)
+  - [Amazon S3](#amazon-s3)
+  - [Backblaze B2](#backblaze-b2)
 - [API methods](#api-methods)
-  * [init](#init)
-  * [test](#test)
-  * [createBucket](#createbucket)
-  * [selectBucket](#selectbucket)
-  * [clearBucket](#clearbucket)
-  * [deleteBucket](#deletebucket)
-  * [listBuckets](#listbuckets)
-  * [getSelectedBucket](#getselectedbucket)
-  * [addFileFromPath](#addfilefrompath)
-  * [addFileFromBuffer](#addfilefrombuffer)
-  * [addFileFromReadable](#addfilefromreadable)
-  * [getFileAsReadable](#getfileasreadable)
-  * [removeFile](#removefile)
-  * [sizeOf](#sizeof)
-  * [fileExists](#fileexists)
-  * [listFiles](#listfiles)
-  * [getType](#gettype)
-  * [getConfiguration](#getconfiguration)
-  * [switchAdapter](#switchadapter)
+  - [init](#init)
+  - [test](#test)
+  - [createBucket](#createbucket)
+  - [selectBucket](#selectbucket)
+  - [clearBucket](#clearbucket)
+  - [deleteBucket](#deletebucket)
+  - [listBuckets](#listbuckets)
+  - [getSelectedBucket](#getselectedbucket)
+  - [addFileFromPath](#addfilefrompath)
+  - [addFileFromBuffer](#addfilefrombuffer)
+  - [addFileFromReadable](#addfilefromreadable)
+  - [getFileAsReadable](#getfileasreadable)
+  - [removeFile](#removefile)
+  - [sizeOf](#sizeof)
+  - [fileExists](#fileexists)
+  - [listFiles](#listfiles)
+  - [getType](#gettype)
+  - [getConfiguration](#getconfiguration)
+  - [switchAdapter](#switchadapter)
 - [How it works](#how-it-works)
 - [Adding more adapters](#adding-more-adapters)
-  * [Define your configuration](#define-your-configuration)
-  * [Adapter class](#adapter-class)
-  * [Adapter function](#adapter-function)
-  * [Register your adapter](#register-your-adapter)
+  - [Define your configuration](#define-your-configuration)
+  - [Adapter class](#adapter-class)
+  - [Adapter function](#adapter-function)
+  - [Register your adapter](#register-your-adapter)
 - [Tests](#tests)
 - [Example application](#example-application)
 - [Questions and requests](#questions-and-requests)
@@ -208,7 +208,7 @@ Configuration object:
 ```typescript
 type ConfigGoogleCloud = {
   type: StorageType;
-  keyFilename: string; // path to keyFile.json
+  keyFilename?: string; // path to keyFile.json
   projectId?: string;
   bucketName?: string;
   slug?: boolean;
@@ -221,7 +221,17 @@ Configuration url:
 const url = "gcs://path/to/keyFile.json:projectId@bucketName?slug=false";
 ```
 
-The project id is optional; if you omit the value for project id, the id will be read from the key file:
+The key filename is optional; if you omit the value for key filename, application default credentials with be loaded:
+
+```typescript
+const s = new Storage({
+  type: StorageType.GCS,
+});
+
+const s = new Storage("gcs://bucketName");
+```
+
+The project id is optional; if you omit the value for project id, the id will be read from the key file or by the application default credentials:
 
 ```typescript
 const s = new Storage({
@@ -230,6 +240,18 @@ const s = new Storage({
 });
 
 const s = new Storage("gcs://path/to/keyFile.json");
+```
+
+The project id is required if the key file is type `.pem` or `.p12`:
+
+```typescript
+const s = new Storage({
+  type: StorageType.GCS,
+  keyFilename: "path/to/keyFile.pem",
+  projectId: "projectId",
+});
+
+const s = new Storage("gcs://path/to/keyFile.pem:projectId");
 ```
 
 Another example:
@@ -323,8 +345,7 @@ type ConfigBackBlazeB2 = {
 Configuration url:
 
 ```typescript
-const url =
-  "b2://applicationKeyId:applicationKey@bucketName&option1=value1&option2=value2&...";
+const url = "b2://applicationKeyId:applicationKey@bucketName&option1=value1&option2=value2&...";
 ```
 
 Example:

--- a/keyFile.json
+++ b/keyFile.json
@@ -1,4 +1,0 @@
-{
-  "note": "this is just a dummy keyFile used for testing!",
-  "project_id": "appIdFromTestFile"
-}

--- a/src/AdapterGoogleCloudStorage.ts
+++ b/src/AdapterGoogleCloudStorage.ts
@@ -35,18 +35,6 @@ export class AdapterGoogleCloudStorage extends AbstractAdapter {
     this.storage = new GoogleCloudStorage(cfg);
   }
 
-  /**
-   * @param {string} keyFile - path to the keyFile
-   *
-   * Read in the keyFile and retrieve the projectId, this is function
-   * is called when the user did not provide a projectId
-   */
-  private getGCSProjectId(keyFile: string): string {
-    const data = fs.readFileSync(keyFile).toString("utf-8");
-    const json = JSON.parse(data);
-    return json.project_id;
-  }
-
   private parseConfig(config: string | ConfigGoogleCloud): ConfigGoogleCloud {
     let cfg: ConfigGoogleCloud;
     if (typeof config === "string") {
@@ -62,12 +50,6 @@ export class AdapterGoogleCloudStorage extends AbstractAdapter {
       };
     } else {
       cfg = { ...config };
-    }
-    if (!cfg.keyFilename) {
-      throw new Error("You must specify a value for 'keyFilename' for storage type 'gcs'");
-    }
-    if (!cfg.projectId) {
-      cfg.projectId = this.getGCSProjectId(cfg.keyFilename);
     }
     return cfg;
   }

--- a/src/types.ts
+++ b/src/types.ts
@@ -187,7 +187,7 @@ export interface ConfigBackblazeB2 extends IAdapterConfig {
 }
 
 export interface ConfigGoogleCloud extends IAdapterConfig {
-  keyFilename: string;
+  keyFilename?: string;
   projectId?: string;
   // [id: string]: GenericKey;
 }

--- a/tests/test-config-gcs.jasmine.ts
+++ b/tests/test-config-gcs.jasmine.ts
@@ -4,7 +4,7 @@ import { StorageType } from "../src/types";
 
 describe(`testing Google urls`, () => {
   it("[0]", () => {
-    this.storage = new Storage("gcs://keyFile.json:appName@the-buck");
+    this.storage = new Storage("gcs://tests/keyFile.json:appName@the-buck");
     expect(this.storage.getType()).toBe(StorageType.GCS);
     expect(this.storage.getSelectedBucket()).toBe("the-buck");
     expect(this.storage.getConfiguration().projectId).toBe("appName");
@@ -12,7 +12,7 @@ describe(`testing Google urls`, () => {
   });
 
   it("[1] don't use trailing slashes", () => {
-    this.storage = new Storage("gcs://keyFile.json:appName/");
+    this.storage = new Storage("gcs://tests/keyFile.json:appName/");
     expect(this.storage.getType()).toBe(StorageType.GCS);
     expect(this.storage.getSelectedBucket()).toBe("");
     expect(this.storage.getConfiguration().projectId).toBe("appName/"); // this will probably yield an error at gcs
@@ -20,7 +20,7 @@ describe(`testing Google urls`, () => {
   });
 
   it("[2] bucketName is optional", () => {
-    this.storage = new Storage("gcs://keyFile.json:appName");
+    this.storage = new Storage("gcs://tests/keyFile.json:appName");
     expect(this.storage.getType()).toBe(StorageType.GCS);
     expect(this.storage.getSelectedBucket()).toBe("");
     expect(this.storage.getConfiguration().projectId).toBe("appName");
@@ -33,19 +33,24 @@ describe(`testing Google urls`, () => {
     }).toThrowError("ENOTDIR: not a directory, open 'tests/keyFile.json/'");
   });
 
-  it("[4] when projectId is not provided it will be read from the keyFile", () => {
-    this.storage = new Storage("gcs://tests/keyFile.json");
+  it("[4] keyFilename is optional", () => {
+    this.storage = new Storage("gcs://the-buck");
     expect(this.storage.getType()).toBe(StorageType.GCS);
-    expect(this.storage.getSelectedBucket()).toBe("");
-    expect(this.storage.getConfiguration().projectId).toBe("appIdFromTestFile");
-    expect(this.storage.getConfiguration().keyFilename).toBe("tests/keyFile.json");
+    expect(this.storage.getSelectedBucket()).toBe("the-buck");
+    expect(this.storage.getConfiguration().keyFilename).toBe("");
   });
 
   it("[4a] projectId is optional", () => {
-    this.storage = new Storage("gcs://tests/keyFile.json@the-buck");
+    this.storage = new Storage("gcs://the-buck");
     expect(this.storage.getType()).toBe(StorageType.GCS);
     expect(this.storage.getSelectedBucket()).toBe("the-buck");
-    expect(this.storage.getConfiguration().projectId).toBe("appIdFromTestFile");
-    expect(this.storage.getConfiguration().keyFilename).toBe("tests/keyFile.json");
+    expect(this.storage.getConfiguration().projectId).toBe("");
+  });
+
+  it("[4a] projectId is optional", () => {
+    this.storage = new Storage("gcs://the-buck");
+    expect(this.storage.getType()).toBe(StorageType.GCS);
+    expect(this.storage.getSelectedBucket()).toBe("the-buck");
+    expect(this.storage.getConfiguration().projectId).toBe("");
   });
 });


### PR DESCRIPTION
Allows the use of default application credentials (if running on a GCE VM or GKE node).

Closes #18 