### PR TITLE
fix(gcs): Fix accessing promise index instead of index' result

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,7 @@
+# [Unreleased]
+
+- fixed gcs signed url generation
+
 # 2.1.3
 
 - updated dependencies

--- a/src/AdapterGoogleCloud.ts
+++ b/src/AdapterGoogleCloud.ts
@@ -66,10 +66,10 @@ export class AdapterGoogleCloud extends AbstractAdapter {
       const file = this._client.bucket(bucketName).file(fileName);
       if (options.useSignedUrl) {
         return {
-          value: await file.getSignedUrl({
+          value: (await file.getSignedUrl({
             action: "read",
             expires: options.expiresOn || 86400,
-          })[0],
+          }))[0],
           error: null,
         };
       } else {


### PR DESCRIPTION
**Summary**:

There is a priority problem between the promise/await and array access. Fix this by prioritizing the promise result over then array access. It was causing the following error : 

```shell
/home/XXXXX/project/src/applications/business/XXXX.ts:5
import {useStorage} from "../../storage";
                                                         ^
Error: An error occurred while trying to generate a signed URL
    at /home/XXXXX/project/src/applications/business/XXXX.ts:114:15
    at Generator.next (<anonymous>)
    at fulfilled (/home/XXXXX/project/src/applications/business/XXXX.ts:5:58)
    at processTicksAndRejections (node:internal/process/task_queues:95:5)
```

The code to reproduce 

```ts
const storage = new Storage({
  type: StorageType.GCS,
  keyFilename: '/path/key.json',
  bucketName: 'my-bucket',
});

await storage.getFileAsURL(data.file.path, {
  useSignedUrl: true,
  expiresOn: Date.now() + 1000 * 60 * 60, // one hour
});
```

**Tested on**

Node 20.12.2
NPM 10.5.0