### PR TITLE
Optional check on add

### DIFF
--- a/src/AbstractAdapter.ts
+++ b/src/AbstractAdapter.ts
@@ -202,8 +202,7 @@ export abstract class AbstractAdapter implements IAdapter {
   protected abstract _sizeOf(bucketName: string, fileName: string): Promise<ResultObjectNumber>;
 
   protected abstract _addFile(
-    params: FilePathParams | FileBufferParams | FileStreamParams,
-    checkIfExists: boolean = true
+    params: FilePathParams | FileBufferParams | FileStreamParams
   ): Promise<ResultObject>;
 
   protected abstract _fileExists(
@@ -356,30 +355,20 @@ export abstract class AbstractAdapter implements IAdapter {
     return this._listFiles(r.value as string, numFiles);
   }
 
-  public async addFileFromPath(
-    params: FilePathParams,
-    checkIfExists: boolean = true
-  ): Promise<ResultObject> {
-    return await this.addFile(params, checkIfExists);
+  public async addFileFromPath(params: FilePathParams): Promise<ResultObject> {
+    return await this.addFile(params);
   }
 
-  public async addFileFromBuffer(
-    params: FileBufferParams,
-    checkIfExists: boolean = true
-  ): Promise<ResultObject> {
-    return await this.addFile(params, checkIfExists);
+  public async addFileFromBuffer(params: FileBufferParams): Promise<ResultObject> {
+    return await this.addFile(params);
   }
 
-  public async addFileFromStream(
-    params: FileStreamParams,
-    checkIfExists: boolean = true
-  ): Promise<ResultObject> {
-    return await this.addFile(params, checkIfExists);
+  public async addFileFromStream(params: FileStreamParams): Promise<ResultObject> {
+    return await this.addFile(params);
   }
 
   public async addFile(
-    params: FilePathParams | FileBufferParams | FileStreamParams,
-    checkIfExists: boolean = true
+    params: FilePathParams | FileBufferParams | FileStreamParams
   ): Promise<ResultObject> {
     const {
       bucketName,
@@ -392,7 +381,7 @@ export abstract class AbstractAdapter implements IAdapter {
     }
 
     // console.log(bucketName, _fn, options, error);
-
+    const checkIfExists = params.options?.checkIfExists ?? true;
     const r = await this.checkBucket(bucketName, checkIfExists);
     if (r.error !== null) {
       return { value: null, error: r.error };

--- a/src/AbstractAdapter.ts
+++ b/src/AbstractAdapter.ts
@@ -381,8 +381,9 @@ export abstract class AbstractAdapter implements IAdapter {
     }
 
     // console.log(bucketName, _fn, options, error);
-    const checkIfExists = params.options?.checkIfExists ?? true;
-    const r = await this.checkBucket(bucketName, checkIfExists);
+    
+    const checkIfBucketExists = params.options?.checkIfBucketExists ?? true;
+    const r = await this.checkBucket(bucketName, checkIfBucketExists);
     if (r.error !== null) {
       return { value: null, error: r.error };
     } else {

--- a/src/AbstractAdapter.ts
+++ b/src/AbstractAdapter.ts
@@ -202,7 +202,8 @@ export abstract class AbstractAdapter implements IAdapter {
   protected abstract _sizeOf(bucketName: string, fileName: string): Promise<ResultObjectNumber>;
 
   protected abstract _addFile(
-    params: FilePathParams | FileBufferParams | FileStreamParams
+    params: FilePathParams | FileBufferParams | FileStreamParams,
+    checkIfExists: boolean = true
   ): Promise<ResultObject>;
 
   protected abstract _fileExists(
@@ -355,20 +356,30 @@ export abstract class AbstractAdapter implements IAdapter {
     return this._listFiles(r.value as string, numFiles);
   }
 
-  public async addFileFromPath(params: FilePathParams): Promise<ResultObject> {
-    return await this.addFile(params);
+  public async addFileFromPath(
+    params: FilePathParams,
+    checkIfExists: boolean = true
+  ): Promise<ResultObject> {
+    return await this.addFile(params, checkIfExists);
   }
 
-  public async addFileFromBuffer(params: FileBufferParams): Promise<ResultObject> {
-    return await this.addFile(params);
+  public async addFileFromBuffer(
+    params: FileBufferParams,
+    checkIfExists: boolean = true
+  ): Promise<ResultObject> {
+    return await this.addFile(params, checkIfExists);
   }
 
-  public async addFileFromStream(params: FileStreamParams): Promise<ResultObject> {
-    return await this.addFile(params);
+  public async addFileFromStream(
+    params: FileStreamParams,
+    checkIfExists: boolean = true
+  ): Promise<ResultObject> {
+    return await this.addFile(params, checkIfExists);
   }
 
   public async addFile(
-    params: FilePathParams | FileBufferParams | FileStreamParams
+    params: FilePathParams | FileBufferParams | FileStreamParams,
+    checkIfExists: boolean = true
   ): Promise<ResultObject> {
     const {
       bucketName,
@@ -382,7 +393,7 @@ export abstract class AbstractAdapter implements IAdapter {
 
     // console.log(bucketName, _fn, options, error);
 
-    const r = await this.checkBucket(bucketName);
+    const r = await this.checkBucket(bucketName, checkIfExists);
     if (r.error !== null) {
       return { value: null, error: r.error };
     } else {


### PR DESCRIPTION
We have a use case where we need to grant minimal permissions to the client and can assume the bucket exists as it is pre-provisioned for them.

Currently in S3 https://github.com/tweedegolf/storage-abstraction/blob/master/src/AdapterAmazonS3.ts#L294 forces to give unrestricted permissions to list the bucket. This is in all prefixes which is what is problematic to us.

This PR exposes the checkIfExists flag in checkBucket in addFile so this can be accomplished.