### PR TITLE
Use checkIfBucketExists option in getFileAsStream

### DIFF
--- a/build/src/AbstractAdapter.js
+++ b/build/src/AbstractAdapter.js
@@ -336,7 +336,11 @@ class AbstractAdapter {
             if (error !== null) {
                 return { value: null, error: error };
             }
-            const r = yield this.checkBucket(bucketName);
+            let checkIfBucketExists = true;
+            if (typeof options.checkIfBucketExists === "boolean") {
+                checkIfBucketExists = options.checkIfBucketExists;
+            }
+            const r = yield this.checkBucket(bucketName, checkIfBucketExists);
             if (r.error !== null) {
                 return { value: null, error: r.error };
             }

--- a/src/AbstractAdapter.ts
+++ b/src/AbstractAdapter.ts
@@ -427,8 +427,12 @@ export abstract class AbstractAdapter implements IAdapter {
     if (error !== null) {
       return { value: null, error: error as string };
     }
+    let checkIfBucketExists = true;
+    if (typeof (options as Options).checkIfBucketExists === "boolean") {
+      checkIfBucketExists = (options as Options).checkIfBucketExists
+    }
 
-    const r = await this.checkBucket(bucketName);
+    const r = await this.checkBucket(bucketName, checkIfBucketExists);
     if (r.error !== null) {
       return { value: null, error: r.error };
     }


### PR DESCRIPTION
It would be nice to use the checkIfBucketExists option for getFileAsStream, as is done in addFile.
That makes it possible to retrieve a file without having the permissions to check for the bucket.